### PR TITLE
[TOON-29] - Added incoming reminder todos to home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetoon-assistant",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.4",

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,0 +1,13 @@
+import { Space } from 'antd-mobile'
+
+import IncomingReminderTodos from './IncomingReminderTodos'
+
+const Home = () => {
+  return (
+    <Space block direction="vertical">
+      <IncomingReminderTodos />
+    </Space>
+  )
+}
+
+export default Home

--- a/src/components/Home/IncomingReminderTodos.tsx
+++ b/src/components/Home/IncomingReminderTodos.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled'
+import { List, Space, Toast } from 'antd-mobile'
+
+import useReminderTodos from 'react-query/useReminderTodos'
+
+const IncomingReminderTodos = () => {
+  const query = useReminderTodos()
+
+  if (query.isLoading) {
+    Toast.show({
+      icon: 'loading',
+      content: 'Loading...',
+    })
+  }
+
+  return (
+    <div>
+      <Title>Incoming reminder todos</Title>
+
+      <Space block direction="vertical">
+        {query.data?.map((item) => (
+          <List key={item.reminder} header={item.reminder}>
+            {item.todos.map((todo) => (
+              <List.Item key={todo.id}>{todo.name}</List.Item>
+            ))}
+          </List>
+        ))}
+      </Space>
+    </div>
+  )
+}
+
+export default IncomingReminderTodos
+
+const Title = styled.span`
+  display: block;
+  font-size: 18px;
+  padding: 12px;
+`

--- a/src/components/Home/index.ts
+++ b/src/components/Home/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Home'

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,9 +1,11 @@
 import AppTabLayout from 'layouts/AppTabLayout'
 
+import Home from 'components/Home'
+
 const HomePage = () => {
   return (
     <AppTabLayout>
-      <h1>Home Page</h1>
+      <Home />
     </AppTabLayout>
   )
 }

--- a/src/react-query/types.ts
+++ b/src/react-query/types.ts
@@ -48,3 +48,8 @@ export interface Todo {
   updated_at: Date
   reminded: boolean
 }
+
+export interface GroupTodo {
+  reminder: string
+  todos: Todo[]
+}

--- a/src/react-query/useReminderTodos.ts
+++ b/src/react-query/useReminderTodos.ts
@@ -1,0 +1,19 @@
+import axios from 'axios'
+import { useQuery } from '@tanstack/react-query'
+
+import type { GroupTodo, QueryResponse } from './types'
+
+const useReminderTodos: QueryResponse<GroupTodo[]> = (options) =>
+  useQuery(
+    ['reminder', 'todo'],
+    async () => {
+      const { data } = await axios.get('/reminder/todos')
+
+      return data
+    },
+    {
+      ...options,
+    }
+  )
+
+export default useReminderTodos


### PR DESCRIPTION
**1. Objective**

Related Link(s):

- https://thetoonishere.atlassian.net/browse/TOON-29

**2. Description of change**

- Added group reminder todos api
- Added incoming reminder todos component

**3. Quality assurance**

- The home page should display incoming reminder todos
- Once todo was reminded should not see again in home page

**4. Operations impact**

None
